### PR TITLE
商品情報編集機能実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,9 +23,26 @@ class ItemsController < ApplicationController
   end
 
   def edit
+    # ログインしているユーザーと同一であればeditファイルが読み込まれる
+    #if @item.user_id == current_user.id && @item.order.nil?
+    #else
+      #redirect_to root_path
+    #end
+    @item = Item.find(params[:id])
   end
 
   def show
+  end
+
+  def update
+    @item.update(item_params)
+    # バリデーションがOKであれば詳細画面へ
+    if @item.valid?
+      redirect_to item_path(item_params)
+    else
+      # NGであれば、エラー内容とデータを保持したままeditファイルを読み込み、エラーメッセージを表示させる
+      render 'edit'
+    end
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,12 +23,11 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    # ログインしているユーザーと同一であればeditファイルが読み込まれる
-    #if @item.user_id == current_user.id && @item.order.nil?
-    #else
-      #redirect_to root_path
-    #end
-    @item = Item.find(params[:id])
+     #ログインしているユーザーと同一であればeditファイルが読み込まれる
+    if @item.user_id == current_user.id 
+    else
+      redirect_to root_path
+    end
   end
 
   def show

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,14 +1,15 @@
-
-<%#div class="items-sell-contents">
+<div class="items-sell-contents">
   <header class="items-sell-header">
     <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
-  <%#/header>
+  </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
+    <%# モデルデータを第一引数とすることで再利用できる %>
     <%= form_with(model: @item, local: true) do |f| %>
-    <%#= render 'shared/error_messages', model: f.object %>
+    <%# インスタンスを渡して、エラー発生時にメッセージを表示する%>
+    <%= render 'shared/error_messages', model: f.object %>
     <%# 出品画像 %>
-    <%#div class="img-upload">
+    <div class="img-upload">
       <div class="weight-bold-text">
         出品画像
         <span class="indispensable">必須</span>
@@ -17,28 +18,29 @@
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :image, id:"item-image" %>
-      <%#/div>
+        <%# form_withのブロック変数を利用して格納されている情報を呼び出す %>
+        <%= f.file_field :image, id:"image" %>
+      </div>
     </div>
     <%# /出品画像 %>
     <%# 商品名と商品説明 %>
-    <%#div class="new-items">
+    <div class="new-items">
       <div class="weight-bold-text">
         商品名
         <span class="indispensable">必須</span>
       </div>
       <%= f.text_area :item_name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
-      <%#div class="items-explain">
+      <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
         <%= f.text_area :item_info, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
-      <%#/div>
+      </div>
     </div>
     <%# /商品名と商品説明 %>
     <%# 商品の詳細 %>
-    <%#div class="items-detail">
+    <div class="items-detail">
       <div class="weight-bold-text">商品の詳細</div>
       <div class="form">
         <div class="weight-bold-text">
@@ -46,16 +48,16 @@
           <span class="indispensable">必須</span>
         </div>
         <%= f.collection_select(:item_category_id, ItemCategory.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
-        <%#div class="weight-bold-text">
+        <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
         <%= f.collection_select(:item_status_id, ItemStatus.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
-      <%#/div>
+      </div>
     </div>
     <%# /商品の詳細 %>
     <%# 配送について %>
-    <%#div class="items-detail">
+    <div class="items-detail">
       <div class="weight-bold-text question-text">
         <span>配送について</span>
         <a class="question" href="#">?</a>
@@ -65,22 +67,22 @@
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:item_shipping_cost_id,ItemShippingCost.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
-        <%#div class="weight-bold-text">
+        <%= f.collection_select(:item_shipping_cost_id,ItemShippingCost.all, :id, :name, {}, {class:"select-box", id:"item_shipping_cost"}) %>
+        <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
-        <%#div class="weight-bold-text">
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"prefecture"}) %>
+        <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:item_shipping_date_id, ItemShippingDate.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
-      <%#/div>
+        <%= f.collection_select(:item_shipping_date_id, ItemShippingDate.all, :id, :name, {}, {class:"select-box", id:"item_shipping_date"}) %>
+      </div>
     </div>
     <%# /配送について %>
     <%# 販売価格 %>
-    <%#div class="sell-price">
+    <div class="sell-price">
       <div class="weight-bold-text question-text">
         <span>販売価格<br>(¥300〜9,999,999)</span>
         <a class="question" href="#">?</a>
@@ -92,8 +94,8 @@
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
-        <%#/div>
+          <%= f.text_field :item_price, class:"price-input", id:"item-price", placeholder:"例）300" %>
+        </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
           <span>
@@ -110,7 +112,7 @@
     </div>
     <%# /販売価格 %>
     <%# 注意書き %>
-    <%#div class="caution">
+    <div class="caution">
       <p class="sentence">
         <a href="#">禁止されている出品、</a>
         <a href="#">行為</a>
@@ -129,23 +131,26 @@
     </div>
     <%# /注意書き %>
     <%# 下部ボタン %>
-    <%#div class="sell-btn-contents">
+    <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%#%= link_to 'もどる', root_path, class:"back-btn" %>
-    <%#/div>
+      <%= link_to 'もどる', item_path, class:"back-btn" %>
+    </div>
     <%# /下部ボタン %>
-  <%#/div>
+  </div>
   <% end %>
 
-  <%#footer class="items-sell-footer">
+  <footer class="items-sell-footer">
     <ul class="menu">
       <li><a href="#">プライバシーポリシー</a></li>
       <li><a href="#">フリマ利用規約</a></li>
       <li><a href="#">特定商取引に関する表記</a></li>
     </ul>
     <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
-    <%#p class="inc">
+    <p class="inc">
       ©︎Furima,Inc.
     </p>
   </footer>
 </div>
+Footer
+© 2022 GitHub, Inc.
+Footer navigation

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,34 +128,32 @@
 
       <%# 商品データがある場合は、eachメソッドで一覧表示する %>
     <% @items.each do |item| %>
-      <%li class='list'>
+      <li class='list'>
         <%= link_to item_path(item) do %>
-          <%div class='item-img-content'>
-              <%= image_tag item.image.variant(resize: '500x500'), class: "item-img" if item.image.attached? %>
-                    <% 商品が売れていればsold outを表示(.present?でも可) %>
-                    <%#if item.order != nil %>
-                      <%#div class='sold-out'>
-                        <span>Sold Out!!</span>
-                      </div>
-                    <% end %>
-                <%/div>
-                <div class='item-info'>
-                <h3 class='item-name'>
-                  <%= item.item_name %>
-                <%/h3>
-                <div class='item-price'>
-                  <%span><%= item.item_price %>円<%br><%= item.item_shipping_cost.name %><%/span>
-                   <div class='star-btn'>
-                   <%= image_tag "star.png", class:"star-icon" %>
-                  <%span class='star-count'>0</span>
-                </div>
-              <% end %>
-            <%/div>
+        <div class='item-img-content'>
+        <%= image_tag item.image.variant(resize: '500x500'), class: "item-img" if item.image.attached? %>
+          <%# 商品が売れていればsold outを表示(.present?でも可) %>
+          <%# if item.order != nil %>
+          <%#div class='sold-out'>
+            <span>Sold Out!!</span>
           </div>
+          <% end %>
+        </div>
+        <div class='item-info'>
+          <h3 class='item-name'>
+            <%= item.item_name %>
+          </h3>
+          <div class='item-price'>
+            <span><%= item.item_price %>円<br><%= item.item_shipping_cost %></span>
+            <div class='star-btn'>
+              <%= image_tag "star.png", class:"star-icon" %>
+              <span class='star-count'>0</span>
+            </div>
+          </div>
+        </div>
         <% end %>
-      <%/li>
-    <% end %>
-
+      </li>
+      <% end %>
   <%# 商品がない場合はダミーを表示する %>
     <% if @items.blank? then %>
       <li class='list'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,11 +25,11 @@
       
       <%= link_to '削除', item_path(@item), method: :delete, class:'item-destroy' %>
     <%# 未購入品でない場合には、売り切れを表示 %>
-    <% elsif @item.order.present? %>
-     <%= link_to "売り切れました",item_path(@item),class:"disabled-button bold" %>
-    <% else %>
+    <%# elsif @item.order.present? %>
+     <%#= link_to "売り切れました",item_path(@item),class:"disabled-button bold" %>
+    <%# else %>
     <%# 出品者以外かつ未購入品であれば、購入画面を表示 %>
-     <%= link_to '購入画面に進む', item_orders_path(@item), class:"item-red-btn"%>
+     <%#= link_to '購入画面に進む', item_orders_path(@item), class:"item-red-btn"%>
     <% end %>
   <% end %>
 
@@ -100,6 +100,6 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%a href="#" class='another-item'><%= @item.item_category.name %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.item_category.name %>をもっと見る</a>
 </div>
 <%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
    root to: 'items#index'
-   resources :items, only: [:index, :new, :create ,:show]  do
+   resources :items, only: [:index, :new, :create ,:show ,:edit ,:update]  do
     #resources :orders, only: [:index, :create]
    end
 end


### PR DESCRIPTION
＃What
商品情報編集機能を実装。
#Why
商品情報編集機能実装するため。

ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/fbc4a289af7402385d3f4ab501a33511

 必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
https://gyazo.com/3ec34c9d66f3186e40ebfa70ef974bfd

 入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
https://gyazo.com/a9fa1ee1ea0b99197bbc0ae470b8d6a9

 何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
https://gyazo.com/902a984a1fd955d7ea47b4ba56c15716

 ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/f79e6d92244b64825ec33e383d1e1087
 
 ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/c34f53c00cf76610d48f17a2c1754a56

 商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
https://gyazo.com/f0be6824183573aaca03c08111c37d7f